### PR TITLE
fix: add headers source to risk chart

### DIFF
--- a/src/components/RiskChart.tsx
+++ b/src/components/RiskChart.tsx
@@ -24,6 +24,9 @@ const RiskChart = () => {
 
   const [{ data, loading }] = useAxios<HouseReport, null, ErrorResponse>({
     url: `reports/house_status`,
+    headers: {
+      source: 'visits',
+    },
   });
 
   const label = `${(user?.team as BaseObject)?.name}: ${t('riskChart.title')}`;


### PR DESCRIPTION
fix: add headers source to risk chart