### PR TITLE
Preserve visit timestamps in the edit form

### DIFF
--- a/src/i18n/locales/en/admin.json
+++ b/src/i18n/locales/en/admin.json
@@ -99,7 +99,7 @@
       "inspectionStatus": "Visit Status: ",
       "statusDescription": "State of the site at the time of the visit",
       "siteNumber": "Site Number",
-      "date": "Date",
+      "date": "Date and time",
       "brigadist": "Brigadist",
       "brigade": "Brigade",
       "household": "Accompanied the visit",

--- a/src/i18n/locales/es/admin.json
+++ b/src/i18n/locales/es/admin.json
@@ -98,7 +98,7 @@
       "inspectionStatus": "Estado de la visita: ",
       "statusDescription": "Estado en el que se encontraba el sitio al momento de la visita",
       "siteNumber": "Número de sitio",
-      "date": "Fecha",
+      "date": "Fecha y hora",
       "brigadist": "Brigadista",
       "brigade": "Brigada",
       "household": "Acompañó la visita",

--- a/src/i18n/locales/pt/admin.json
+++ b/src/i18n/locales/pt/admin.json
@@ -98,7 +98,7 @@
       "inspectionStatus": "Estado da visita: ",
       "statusDescription": "Estado em que se encontrava o local no momento da visita",
       "siteNumber": "Número do local",
-      "date": "Data",
+      "date": "Data e hora",
       "brigadist": "Brigadista",
       "brigade": "Brigada",
       "household": "Acompanhou a visita",

--- a/src/pages/visits/EditVisitPage.tsx
+++ b/src/pages/visits/EditVisitPage.tsx
@@ -35,6 +35,7 @@ import YellowHouse from '@/assets/icons/house-yellow.svg';
 import EditInspectionDialog from '@/components/dialog/EditInspectionDialog';
 import FilteredDataTable from '@/components/list/FilteredDataTable';
 import { INSPECTIONS_CREATE } from '@/constants/permissions';
+import useLangContext from '@/hooks/useLangContext';
 import useUpdateMutation from '@/hooks/useUpdateMutation';
 import ProtectedView from '@/layout/ProtectedView';
 import type { FormSelectOption } from '@/schemas';
@@ -45,7 +46,7 @@ import FormSelectAutocomplete from '@/themed/form-select-autocomplete/FormSelect
 import FormSelect from '@/themed/form-select/FormSelect';
 import type { HeadCell } from '@/themed/table/DataTable';
 import Text from '@/themed/text/Text';
-import { convertToFormSelectOptions, downloadFile, extractAxiosErrorData } from '@/util';
+import { convertToFormSelectOptions, downloadFile, extractAxiosErrorData, formatDateFromString } from '@/util';
 import { Button } from '../../themed/button/Button';
 import FormInput from '../../themed/form-input/FormInput';
 import { Title } from '../../themed/title/Title';
@@ -229,6 +230,7 @@ function HouseStatusBanner({ color: colorPlain }: HouseStatusProps) {
 
 export function EditVisit({ visit, refetch }: EditVisitProps) {
   const { t } = useTranslation(['register', 'errorCodes', 'admin', 'translation', 'questionnaire']);
+  const langContext = useLangContext();
   const navigate = useNavigate();
 
   const [selectedInspection, setSelectedInspection] = useState<Inspection | null>(null);
@@ -240,7 +242,7 @@ export function EditVisit({ visit, refetch }: EditVisitProps) {
   const rootElement = document.getElementById('root-app');
   // fetched from attributes (passed as state) update after endpoint
   const status = visit.visitStatus;
-  const date = visit.visitedAt;
+  const formattedDate = formatDateFromString(langContext.state.selected, visit.visitedAt);
 
   const startSideOptions: FormSelectOption[] = (visit.startSide || []).map((option) => ({
     label: option.label,
@@ -264,7 +266,7 @@ export function EditVisit({ visit, refetch }: EditVisitProps) {
   const methods = useForm({
     defaultValues: {
       site: defaultHouse,
-      date,
+      date: visit.visitedAt,
       brigadist: visit.brigadist ? String((visit?.brigadist as BaseEntity)?.id) : '',
       brigade: visit.team ? String((visit?.team as BaseEntity)?.name) : '',
       visitPermission: (visit.visitPermission || []).find((i) => i.selected)?.label ?? '',
@@ -466,7 +468,7 @@ export function EditVisit({ visit, refetch }: EditVisitProps) {
               /
             </Text>
             <Text type="menuItem" className="opacity-50">
-              {date}
+              {formattedDate}
             </Text>
           </Box>
 

--- a/src/pages/visits/EditVisitPage.tsx
+++ b/src/pages/visits/EditVisitPage.tsx
@@ -35,7 +35,6 @@ import YellowHouse from '@/assets/icons/house-yellow.svg';
 import EditInspectionDialog from '@/components/dialog/EditInspectionDialog';
 import FilteredDataTable from '@/components/list/FilteredDataTable';
 import { INSPECTIONS_CREATE } from '@/constants/permissions';
-import useLangContext from '@/hooks/useLangContext';
 import useUpdateMutation from '@/hooks/useUpdateMutation';
 import ProtectedView from '@/layout/ProtectedView';
 import type { FormSelectOption } from '@/schemas';
@@ -46,7 +45,7 @@ import FormSelectAutocomplete from '@/themed/form-select-autocomplete/FormSelect
 import FormSelect from '@/themed/form-select/FormSelect';
 import type { HeadCell } from '@/themed/table/DataTable';
 import Text from '@/themed/text/Text';
-import { convertToFormSelectOptions, downloadFile, extractAxiosErrorData, formatDateFromString } from '@/util';
+import { convertToFormSelectOptions, downloadFile, extractAxiosErrorData } from '@/util';
 import { Button } from '../../themed/button/Button';
 import FormInput from '../../themed/form-input/FormInput';
 import { Title } from '../../themed/title/Title';
@@ -230,7 +229,6 @@ function HouseStatusBanner({ color: colorPlain }: HouseStatusProps) {
 
 export function EditVisit({ visit, refetch }: EditVisitProps) {
   const { t } = useTranslation(['register', 'errorCodes', 'admin', 'translation', 'questionnaire']);
-  const langContext = useLangContext();
   const navigate = useNavigate();
 
   const [selectedInspection, setSelectedInspection] = useState<Inspection | null>(null);
@@ -242,7 +240,7 @@ export function EditVisit({ visit, refetch }: EditVisitProps) {
   const rootElement = document.getElementById('root-app');
   // fetched from attributes (passed as state) update after endpoint
   const status = visit.visitStatus;
-  const date = formatDateFromString(langContext.state.selected, visit.visitedAt);
+  const date = visit.visitedAt;
 
   const startSideOptions: FormSelectOption[] = (visit.startSide || []).map((option) => ({
     label: option.label,
@@ -585,7 +583,7 @@ export function EditVisit({ visit, refetch }: EditVisitProps) {
                 className="mt-2 h-full"
                 name="date"
                 label={t('admin:visits.inspection.date')}
-                type="date-picker"
+                type="date-time-picker"
               />
             </Grid>
             <Grid

--- a/src/themed/form-input/FormInput.tsx
+++ b/src/themed/form-input/FormInput.tsx
@@ -7,7 +7,11 @@ import {
   type TextFieldProps,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { DateField as MUIDateField, DatePicker as MUIDatePicker } from '@mui/x-date-pickers';
+import {
+  DateField as MUIDateField,
+  DatePicker as MUIDatePicker,
+  DateTimePicker as MUIDateTimePicker,
+} from '@mui/x-date-pickers';
 import { useTranslation } from 'react-i18next';
 
 import dayjs, { Dayjs } from 'dayjs';
@@ -48,6 +52,30 @@ export const DateField = styled(MUIDateField)`
 `;
 
 export const DatePicker = styled(MUIDatePicker)`
+  .MuiInputBase-root.MuiInput-root:before,
+  .MuiInputBase-root.MuiInput-root:after,
+  .MuiInputBase-root.MuiInput-root:hover:before,
+  .MuiInputBase-root.MuiInput-root:hover {
+    content: '';
+    border-bottom: 0px;
+  }
+  .Mui-error {
+    input {
+      border-color: ${COLORS.red};
+      color: ${COLORS.red};
+    }
+  }
+  &.MuiTextField-root {
+    border-color: ${COLORS.fieldBorder};
+    &.Mui-error,
+    &:has(.Mui-error) {
+      border-color: ${COLORS.red};
+      color: ${COLORS.red};
+    }
+  }
+`;
+
+const DateTimePicker = styled(MUIDateTimePicker)`
   .MuiInputBase-root.MuiInput-root:before,
   .MuiInputBase-root.MuiInput-root:after,
   .MuiInputBase-root.MuiInput-root:hover:before,
@@ -253,6 +281,39 @@ export default function FormInput({
                   label,
                   variant: 'outlined',
                   value: dayjs(field.value),
+                  onBlur: field.onBlur,
+                  fullWidth,
+                  error: !!fieldError,
+                },
+              }}
+              sx={
+                fontVariant
+                  ? {
+                      fontFamily: 'Inter',
+                    }
+                  : {}
+              }
+            />
+          )}
+          {type === 'date-time-picker' && (
+            <DateTimePicker
+              value={field.value ? dayjs(field.value) : null}
+              localeText={{
+                fieldYearPlaceholder: () => t('YYYY'),
+              }}
+              format="YYYY/MM/DD HH:mm"
+              ampm={false}
+              className={className}
+              inputRef={ref}
+              onChange={(value: Dayjs | null) => {
+                if (value?.isValid()) {
+                  field.onChange(value.toISOString());
+                }
+              }}
+              slotProps={{
+                textField: {
+                  label,
+                  variant: 'outlined',
                   onBlur: field.onBlur,
                   fullWidth,
                   error: !!fieldError,

--- a/src/themed/form-input/FormInput.tsx
+++ b/src/themed/form-input/FormInput.tsx
@@ -7,14 +7,10 @@ import {
   type TextFieldProps,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import {
-  DateField as MUIDateField,
-  DatePicker as MUIDatePicker,
-  DateTimePicker as MUIDateTimePicker,
-} from '@mui/x-date-pickers';
+import { DateTimePicker as MUIDateTimePicker } from '@mui/x-date-pickers';
 import { useTranslation } from 'react-i18next';
 
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs, { type Dayjs } from 'dayjs';
 import { MuiTelInput } from 'mui-tel-input';
 import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
@@ -28,52 +24,6 @@ import { twMerge } from 'tailwind-merge';
 import { COLORS } from '../../constants';
 import { getProperty } from '../../util';
 import { FormInputError, type FieldErrorType } from './FormInputError';
-
-export const DateField = styled(MUIDateField)`
-  .MuiInputBase-root.MuiInput-root:before,
-  .MuiInputBase-root.MuiInput-root:after,
-  .MuiInputBase-root.MuiInput-root:hover:before,
-  .MuiInputBase-root.MuiInput-root:hover {
-    content: '';
-    border-bottom: 0px;
-  }
-  .Mui-error {
-    input {
-      border-color: ${COLORS.red};
-      color: ${COLORS.red};
-    }
-  }
-  & input {
-    &.Mui-error {
-      border-color: ${COLORS.red};
-      color: ${COLORS.red};
-    }
-  }
-`;
-
-export const DatePicker = styled(MUIDatePicker)`
-  .MuiInputBase-root.MuiInput-root:before,
-  .MuiInputBase-root.MuiInput-root:after,
-  .MuiInputBase-root.MuiInput-root:hover:before,
-  .MuiInputBase-root.MuiInput-root:hover {
-    content: '';
-    border-bottom: 0px;
-  }
-  .Mui-error {
-    input {
-      border-color: ${COLORS.red};
-      color: ${COLORS.red};
-    }
-  }
-  &.MuiTextField-root {
-    border-color: ${COLORS.fieldBorder};
-    &.Mui-error,
-    &:has(.Mui-error) {
-      border-color: ${COLORS.red};
-      color: ${COLORS.red};
-    }
-  }
-`;
 
 const DateTimePicker = styled(MUIDateTimePicker)`
   .MuiInputBase-root.MuiInput-root:before,
@@ -263,38 +213,6 @@ export default function FormInput({
               {...otherProps}
             />
           )}
-          {type === 'date-picker' && (
-            <DatePicker
-              localeText={{
-                fieldYearPlaceholder: () => t('YYYY'),
-              }}
-              format="YYYY/MM/DD"
-              className={className}
-              onChange={(value: unknown) => {
-                const date = value as Dayjs;
-                if (date.isValid()) {
-                  field.onChange(date.toISOString());
-                }
-              }}
-              slotProps={{
-                textField: {
-                  label,
-                  variant: 'outlined',
-                  value: dayjs(field.value),
-                  onBlur: field.onBlur,
-                  fullWidth,
-                  error: !!fieldError,
-                },
-              }}
-              sx={
-                fontVariant
-                  ? {
-                      fontFamily: 'Inter',
-                    }
-                  : {}
-              }
-            />
-          )}
           {type === 'date-time-picker' && (
             <DateTimePicker
               value={field.value ? dayjs(field.value) : null}
@@ -314,33 +232,6 @@ export default function FormInput({
                 textField: {
                   label,
                   variant: 'outlined',
-                  onBlur: field.onBlur,
-                  fullWidth,
-                  error: !!fieldError,
-                },
-              }}
-              sx={
-                fontVariant
-                  ? {
-                      fontFamily: 'Inter',
-                    }
-                  : {}
-              }
-            />
-          )}
-          {type === 'date-field' && (
-            <DateField
-              onChange={(value: unknown) => {
-                const date = value as Dayjs;
-                if (date.isValid()) {
-                  field.onChange(date.toISOString());
-                }
-              }}
-              variant="outlined"
-              slotProps={{
-                textField: {
-                  label,
-                  value: dayjs(field.value),
                   onBlur: field.onBlur,
                   fullWidth,
                   error: !!fieldError,


### PR DESCRIPTION
## Summary

- Replace the visit edit date-only field with a 24-hour date-time picker.
- Preserve the visit’s original ISO timestamp so saving no longer resets the time and unexpectedly changes its table position.
- Remove the unused date-only `FormInput` variants and update the English, Spanish, and Portuguese field labels.